### PR TITLE
fix(email-support): fix email redirect

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,7 +45,7 @@ ratelimiter.limiter.init_app(app=app)
 app.config['INFO'] = {
     'description': 'The API for Derailed.',
     'termsOfService': 'https://derailed.one/terms',
-    'contact': {'name': 'Support', 'email': 'support@derailed.one'},
+    'contact': {'name': 'Support', 'email': 'mailto:support@derailed.one'},
     'license': {
         'name': 'Apache-2.0',
         'url': 'https://www.apache.org/licenses/LICENSE-2.0',


### PR DESCRIPTION
This pull request fixes the email redirect on the `Contact Support` hyperlink, as it currently redirects to `https://derailed.one/mailto:support@derailed.one` instead of `mailto:support@derailed.one.` **This has not been tested.**